### PR TITLE
Added autodiscovery

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -2,24 +2,20 @@ import './App.css'
 import BoardStatusDashboard from './components/BoardStatus/BoardStatusDashboard'
 import ConnectToOmnibus from './components/ConnectToOmnibus'
 import { useOmnibusStore } from '@/store/omnibusStore'
-import { identifiers } from '@/components/types'
 import { useShallow } from 'zustand/react/shallow'
 import { OmnibusProvider } from './components/OmnibusProvider'
-import type { DataFormat } from '@/components/types'
 
 function AppContent() {
     // setting up zustand store
     const series = useOmnibusStore(useShallow((state) => state.series))
 
-    const boardData = identifiers.map(({ type_id, inst_id }) => {
-        const key = `${type_id}-${inst_id}`
-        const msg = series[key]
+    const boardData = Object.values(series).map((msg) => {
         return {
-            boardTypeId: type_id,
-            boardInstId: inst_id,
-            msgPriority: msg?.msgPrio ?? 'prio',
-            msgType: msg?.msgType ?? 'type',
-            data: (msg?.data as DataFormat | null) ?? null,
+            boardTypeId: msg.boardTypeId,
+            boardInstId: msg.boardInstId,
+            msgPriority: msg.msgPrio,
+            msgType: msg.msgType,
+            data: (msg.data as Record<string, string | number> | null) ?? null,
         }
     })
 

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -2,12 +2,11 @@ import './App.css'
 import BoardStatusDashboard from './components/BoardStatus/BoardStatusDashboard'
 import ConnectToOmnibus from './components/ConnectToOmnibus'
 import { useOmnibusStore } from '@/store/omnibusStore'
-import { useShallow } from 'zustand/react/shallow'
 import { OmnibusProvider } from './components/OmnibusProvider'
 
 function AppContent() {
     // setting up zustand store
-    const series = useOmnibusStore(useShallow((state) => state.series))
+    const series = useOmnibusStore((state) => state.series)
 
     const boardData = Object.values(series).map((msg) => {
         return {

--- a/packages/renderer/src/components/types.ts
+++ b/packages/renderer/src/components/types.ts
@@ -4,21 +4,4 @@ export interface BoardMessage<T extends Record<keyof T, string | number>> {
     msgPriority: string
     msgType: string
     data: T | undefined | null
-};
-
-interface Identifier {
-    type_id: string;
-    inst_id: string;
-}
-
-export const identifiers: Identifier[] = [
-    { type_id: 'TYPE-1', inst_id: 'INST-1' },
-    { type_id: 'TYPE-2', inst_id: 'INST-2' },
-    { type_id: 'TYPE-3', inst_id: 'INST-3' },
-    { type_id: 'TYPE-4', inst_id: 'INST-4' },
-]
-
-export interface DataFormat {
-    status: string
-    value: number
 }

--- a/packages/renderer/tests/App.integration.test.tsx
+++ b/packages/renderer/tests/App.integration.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { OmnibusProvider } from '@/components/OmnibusProvider'
 import App from '@/App'
 import { spawn, ChildProcess } from 'child_process'
 import { fileURLToPath } from 'url'

--- a/packages/renderer/tests/mock-backend/server.ts
+++ b/packages/renderer/tests/mock-backend/server.ts
@@ -7,7 +7,7 @@ interface Identifier {
     inst_id: string
 }
 
-export const identifiers: Identifier[] = [
+const identifiers: Identifier[] = [
     { type_id: 'TYPE-1', inst_id: 'INST-1' },
     { type_id: 'TYPE-2', inst_id: 'INST-2' },
     { type_id: 'TYPE-3', inst_id: 'INST-3' },


### PR DESCRIPTION
### Goal of PR:
Changed the way boards are displayed so there are no longer hard-coded board IDs subscribed to the Zustand store. Instead, the boards that are stored in the Zustand store are displayed. The Zustand store handles updating existing boards with new data and adding new boards if they do not already exist.

### Other file changes:
Did a little bit of cleanup since I am no longer using some things.

https://github.com/user-attachments/assets/438d73d2-7803-4993-a22d-b85004951699



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined board data transformation process for improved internal efficiency.
  * Removed unused internal type definitions and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->