### PR TITLE
Implement the CAN Command Sender

### DIFF
--- a/mock-server/package-lock.json
+++ b/mock-server/package-lock.json
@@ -1,0 +1,291 @@
+{
+  "name": "omnibus-mock-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "omnibus-mock-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "socket.io": "^4.8.1",
+        "socket.io-msgpack-parser": "^3.0.2"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/notepack.io": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
+      "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.20.1"
+      }
+    },
+    "node_modules/socket.io-msgpack-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/socket.io-msgpack-parser/-/socket.io-msgpack-parser-3.0.2.tgz",
+      "integrity": "sha512-1e76bJ1PCKi9H+JiYk+S29PBJvknHjQWM7Mtj0hjF2KxDA6b6rQxv3rTsnwBoz/haZOhlCDIMQvPATbqYeuMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "~1.3.0",
+        "notepack.io": "~2.2.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "omnibus-mock-server",
+  "version": "1.0.0",
+  "description": "Mock Omnibus server for local CAN sender testing",
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "socket.io": "^4.8.1",
+    "socket.io-msgpack-parser": "^3.0.2"
+  }
+}

--- a/mock-server/server.mjs
+++ b/mock-server/server.mjs
@@ -1,0 +1,94 @@
+/**
+ * Mock Omnibus server for manual CAN sender testing.
+ *
+ * - Accepts connections from the app (connect to http://localhost:8081)
+ * - Logs every CAN/Commands message the app sends
+ * - Emits a handful of fake CAN/Parsley board-status messages on connect
+ *   so the board status panel populates too
+ *
+ * Usage:
+ *   cd mock-server && npm install && npm start
+ *
+ * Then in the app, click "Connect to Omnibus" and enter: http://localhost:8081
+ */
+
+import { createServer } from 'http'
+import { Server } from 'socket.io'
+import * as msgpackParser from 'socket.io-msgpack-parser'
+
+const PORT = 8082
+
+const httpServer = createServer()
+const io = new Server(httpServer, {
+    cors: { origin: '*' },
+    parser: msgpackParser,
+})
+
+// ---------------------------------------------------------------------------
+// Fake boards to populate the status dashboard on connect
+// ---------------------------------------------------------------------------
+const FAKE_BOARDS = [
+    {
+        board_type_id: 'SENSOR_BOARD',
+        board_inst_id: '0',
+        msg_prio: 'MEDIUM',
+        msg_type: 'SENSOR_STATUS',
+        data: { temperature: 23.4, pressure: 101325, voltage: 3.3 },
+        parsley: '',
+        message_format_version: 2,
+    },
+    {
+        board_type_id: 'FLIGHT_COMPUTER',
+        board_inst_id: '0',
+        msg_prio: 'HIGH',
+        msg_type: 'STATE',
+        data: { state: 'IDLE', uptime_ms: 12345 },
+        parsley: '',
+        message_format_version: 2,
+    },
+    {
+        board_type_id: 'INJECTOR_VALVE',
+        board_inst_id: '1',
+        msg_prio: 'HIGHEST',
+        msg_type: 'VALVE_STATUS',
+        data: { position: 'CLOSED', actuations: 0 },
+        parsley: '',
+        message_format_version: 2,
+    },
+]
+
+// ---------------------------------------------------------------------------
+// Connection handler
+// ---------------------------------------------------------------------------
+io.on('connection', (socket) => {
+    console.log(`[mock] Client connected: ${socket.id}`)
+
+    // Send fake board statuses so the dashboard has something to show
+    for (const board of FAKE_BOARDS) {
+        socket.emit('CAN/Parsley', Date.now(), board)
+    }
+    console.log(`[mock] Emitted ${FAKE_BOARDS.length} fake board status messages`)
+
+    // Log every CAN/Commands message the app sends
+    socket.onAny((channel, timestamp, payload) => {
+        if (channel === 'CAN/Commands') {
+            console.log('\n[mock] ← CAN/Commands received:')
+            console.log('  timestamp:', timestamp)
+            console.log('  payload:  ', JSON.stringify(payload, null, 4))
+
+            // Echo it back as a CAN/Parsley update on the target board so the
+            // board status panel reflects the command was "received"
+        } else {
+            console.log(`[mock] ← ${channel}:`, JSON.stringify(payload))
+        }
+    })
+
+    socket.on('disconnect', () => {
+        console.log(`[mock] Client disconnected: ${socket.id}`)
+    })
+})
+
+httpServer.listen(PORT, () => {
+    console.log(`\nOmnibus mock server running on http://localhost:${PORT}`)
+    console.log(`In the app, click "Connect to Omnibus" and enter: http://localhost:${PORT}\n`)
+})

--- a/mock-server/server.mjs
+++ b/mock-server/server.mjs
@@ -9,7 +9,7 @@
  * Usage:
  *   cd mock-server && npm install && npm start
  *
- * Then in the app, click "Connect to Omnibus" and enter: http://localhost:8081
+ * Then in the app, click "Connect to Omnibus" and enter: http://localhost:8082
  */
 
 import { createServer } from 'http'

--- a/mock-server/server.mjs
+++ b/mock-server/server.mjs
@@ -1,7 +1,7 @@
 /**
  * Mock Omnibus server for manual CAN sender testing.
  *
- * - Accepts connections from the app (connect to http://localhost:8081)
+ * - Accepts connections from the app (connect to http://localhost:8082)
  * - Logs every CAN/Commands message the app sends
  * - Emits a handful of fake CAN/Parsley board-status messages on connect
  *   so the board status panel populates too
@@ -75,9 +75,6 @@ io.on('connection', (socket) => {
             console.log('\n[mock] ← CAN/Commands received:')
             console.log('  timestamp:', timestamp)
             console.log('  payload:  ', JSON.stringify(payload, null, 4))
-
-            // Echo it back as a CAN/Parsley update on the target board so the
-            // board status panel reflects the command was "received"
         } else {
             console.log(`[mock] ← ${channel}:`, JSON.stringify(payload))
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5358,7 +5358,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -5636,6 +5635,7 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",

--- a/packages/renderer/src/components/CanSender/CanSender.tsx
+++ b/packages/renderer/src/components/CanSender/CanSender.tsx
@@ -1,170 +1,328 @@
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import * as z from "zod"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { useState } from 'react'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog'
+import { useOmnibus } from '@/components/OmnibusProvider'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import { CommandHistory } from './CommandHistory'
+import { Favorites } from './Favorites'
 
-const formSchema = z.object({
-  msg_type: z.string(),
-  msg_prio: z.string(),
-  board_type_id: z.string(),
-  board_inst_id: z.string(),
-  time: z.string().refine((val) => {
-    if (val.trim() === "") return true
-    return !isNaN(parseInt(val, 10))
-  }, {
-    message: "Must be a valid integer",
-  }),
-})
+const MSG_PRIOS = ['LOW', 'MEDIUM', 'HIGH', 'HIGHEST'] as const
+type MsgPrio = (typeof MSG_PRIOS)[number]
 
-type FormData = z.infer<typeof formSchema>
+interface FormState {
+    board_type_id: string
+    board_inst_id: string
+    msg_type: string
+    msg_prio: MsgPrio
+    can_msg: string
+    parsley_instance: string
+}
+
+interface FormErrors {
+    board_type_id?: string
+    board_inst_id?: string
+    msg_type?: string
+    can_msg?: string
+    parsley_instance?: string
+}
+
+const DEFAULT_FORM: FormState = {
+    board_type_id: '',
+    board_inst_id: '',
+    msg_type: '',
+    msg_prio: 'MEDIUM',
+    can_msg: '',
+    parsley_instance: '',
+}
+
+function parsePayload(raw: string): unknown {
+    const trimmed = raw.trim()
+    if (!trimmed) return null
+    try {
+        return JSON.parse(trimmed)
+    } catch {}
+    const hex = trimmed.replace(/^0x/i, '').replace(/\s+/g, '')
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+        throw new Error('Payload must be valid JSON or an even-length hex string (e.g. DEADBEEF)')
+    }
+    if (hex.length / 2 > 8) {
+        throw new Error('CAN payload exceeds 8 bytes')
+    }
+    const bytes: number[] = []
+    for (let i = 0; i < hex.length; i += 2) {
+        bytes.push(parseInt(hex.slice(i, i + 2), 16))
+    }
+    return bytes
+}
+
+function validate(fields: FormState): FormErrors {
+    const errors: FormErrors = {}
+    if (!fields.board_type_id.trim()) errors.board_type_id = 'Required'
+    if (!fields.board_inst_id.trim()) errors.board_inst_id = 'Required'
+    if (!fields.msg_type.trim()) errors.msg_type = 'Required'
+    if (!fields.parsley_instance.trim()) errors.parsley_instance = 'Required'
+    if (fields.can_msg.trim()) {
+        try {
+            parsePayload(fields.can_msg)
+        } catch (e) {
+            errors.can_msg = e instanceof Error ? e.message : 'Invalid payload'
+        }
+    }
+    return errors
+}
+
+function buildCommand(fields: FormState): CANCommandMessage {
+    return {
+        boardTypeId: fields.board_type_id.trim(),
+        boardInstId: fields.board_inst_id.trim(),
+        msgType: fields.msg_type.trim(),
+        msgPrio: fields.msg_prio,
+        canMsg: fields.can_msg.trim() ? parsePayload(fields.can_msg) : null,
+        parsley: fields.parsley_instance.trim(),
+        messageFormatVersion: 2,
+    }
+}
 
 export function CanSender() {
-  const form = useForm<FormData>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      msg_type: "",
-      msg_prio: "",
-      board_type_id: "",
-      board_inst_id: "",
-      time: "",
-    },
-  })
+    const { sendCommand, connectionStatus, parsleyInstances } = useOmnibus()
+    const [fields, setFields] = useState<FormState>(DEFAULT_FORM)
+    const [errors, setErrors] = useState<FormErrors>({})
+    const [sendStatus, setSendStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+    const [favLabel, setFavLabel] = useState('')
+    const [favDialogOpen, setFavDialogOpen] = useState(false)
+    const [collapsed, setCollapsed] = useState(false)
 
-  const onSubmit = (data: FormData) => {
-    // Convert values to JSON format
-    const parsedData = {
-      msg_type: data.msg_type.trim() || null,
-      msg_prio: data.msg_prio.trim() || null,
-      board_type_id: data.board_type_id.trim() || null,
-      board_inst_id: data.board_inst_id.trim() || null,
-      time: data.time.trim() ? parseInt(data.time, 10) : null,
+    const set = (key: keyof FormState) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        setFields((prev) => ({ ...prev, [key]: e.target.value }))
+        setErrors((prev) => ({ ...prev, [key]: undefined }))
     }
-    console.log(parsedData)
-  }
 
-  return (
-    <div className="flex items-center justify-center min-h-screen">
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <div className="flex flex-col items-stretch gap-3 bg-zinc-900 p-4 rounded-lg">
-          {/* msg_type */}
-          <FormField
-            control={form.control}
-            name="msg_type"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormLabel className="text-xs text-zinc-400">msg_type </FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    className="bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500"
-                    placeholder="str"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+    const handleSend = () => {
+        const errs = validate(fields)
+        if (Object.keys(errs).length > 0) {
+            setErrors(errs)
+            return
+        }
+
+        let cmd: CANCommandMessage
+        try {
+            cmd = buildCommand(fields)
+        } catch (e) {
+            setSendStatus({ type: 'error', message: e instanceof Error ? e.message : 'Invalid payload' })
+            return
+        }
+
+        try {
+            sendCommand(cmd)
+            useCanSenderStore.getState().addToHistory({ timestamp: Date.now(), command: cmd, status: 'success' })
+            setSendStatus({ type: 'success', message: 'Command sent' })
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : 'Failed to send'
+            useCanSenderStore.getState().addToHistory({ timestamp: Date.now(), command: cmd, status: 'error', errorMessage: msg })
+            setSendStatus({ type: 'error', message: msg })
+        }
+    }
+
+    const loadCommand = (cmd: CANCommandMessage) => {
+        setFields({
+            board_type_id: cmd.boardTypeId,
+            board_inst_id: cmd.boardInstId,
+            msg_type: cmd.msgType,
+            msg_prio: cmd.msgPrio,
+            can_msg: cmd.canMsg != null ? JSON.stringify(cmd.canMsg) : '',
+            parsley_instance: cmd.parsley,
+        })
+        setErrors({})
+        setSendStatus(null)
+    }
+
+    const saveFavorite = () => {
+        const errs = validate(fields)
+        if (Object.keys(errs).length > 0) return
+        try {
+            const cmd = buildCommand(fields)
+            useCanSenderStore.getState().addFavorite(
+                favLabel.trim() || `${fields.board_type_id}/${fields.msg_type}`,
+                cmd,
+            )
+        } catch {
+            return
+        }
+        setFavLabel('')
+        setFavDialogOpen(false)
+    }
+
+    const inputClass = 'bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500'
+    const labelClass = 'text-xs text-zinc-400'
+    const errorClass = 'text-xs text-red-400 mt-1'
+
+    return (
+        <div className="p-4 space-y-4">
+            <button
+                type="button"
+                onClick={() => setCollapsed((c) => !c)}
+                className="flex items-center gap-2 text-sm font-semibold text-zinc-900 hover:text-zinc-600 transition-colors"
+            >
+                <span className={`transition-transform duration-200 ${collapsed ? '-rotate-90' : ''}`}>▾</span>
+                CAN Sender
+            </button>
+
+            {!collapsed && (
+                <>
+                    <div className="flex gap-4 flex-wrap items-start">
+                        {/* Form */}
+                        <div className="flex flex-col gap-3 bg-zinc-900 p-4 rounded-lg flex-1 min-w-[260px]">
+                            <div>
+                                <Label className={labelClass}>board_type_id</Label>
+                                <Input
+                                    className={inputClass}
+                                    placeholder="e.g. SENSOR_BOARD"
+                                    value={fields.board_type_id}
+                                    onChange={set('board_type_id')}
+                                />
+                                {errors.board_type_id && <p className={errorClass}>{errors.board_type_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label className={labelClass}>board_inst_id</Label>
+                                <Input
+                                    className={inputClass}
+                                    placeholder="e.g. 0"
+                                    value={fields.board_inst_id}
+                                    onChange={set('board_inst_id')}
+                                />
+                                {errors.board_inst_id && <p className={errorClass}>{errors.board_inst_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label className={labelClass}>msg_type</Label>
+                                <Input
+                                    className={inputClass}
+                                    placeholder="e.g. ACTUATE"
+                                    value={fields.msg_type}
+                                    onChange={set('msg_type')}
+                                />
+                                {errors.msg_type && <p className={errorClass}>{errors.msg_type}</p>}
+                            </div>
+
+                            <div>
+                                <Label className={labelClass}>msg_prio</Label>
+                                <select
+                                    className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-md h-9 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                                    value={fields.msg_prio}
+                                    onChange={set('msg_prio')}
+                                >
+                                    {MSG_PRIOS.map((p) => (
+                                        <option key={p} value={p}>{p}</option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            <div>
+                                <Label className={labelClass}>payload — JSON or hex, max 8 bytes (optional)</Label>
+                                <Input
+                                    className={`${inputClass} font-mono`}
+                                    placeholder='{"key": 1}  or  DEADBEEF'
+                                    value={fields.can_msg}
+                                    onChange={set('can_msg')}
+                                />
+                                {errors.can_msg && <p className={errorClass}>{errors.can_msg}</p>}
+                            </div>
+
+                            <div>
+                                <Label className={labelClass}>parsley instance</Label>
+                                {parsleyInstances.length > 0 ? (
+                                    <select
+                                        className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-md h-9 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-zinc-500"
+                                        value={fields.parsley_instance}
+                                        onChange={set('parsley_instance')}
+                                    >
+                                        <option value="">Select parsley instance…</option>
+                                        {parsleyInstances.map((id) => (
+                                            <option key={id} value={id}>{id}</option>
+                                        ))}
+                                    </select>
+                                ) : (
+                                    <Input
+                                        className={inputClass}
+                                        placeholder="e.g. hostname/usb/COM3"
+                                        value={fields.parsley_instance}
+                                        onChange={set('parsley_instance')}
+                                    />
+                                )}
+                                {errors.parsley_instance && <p className={errorClass}>{errors.parsley_instance}</p>}
+                            </div>
+
+                            <div className="flex gap-2">
+                                <Button
+                                    type="button"
+                                    className="bg-zinc-700 hover:bg-zinc-600 text-white flex-1"
+                                    disabled={connectionStatus !== 'connected'}
+                                    onClick={handleSend}
+                                >
+                                    SEND
+                                </Button>
+
+                                <Dialog open={favDialogOpen} onOpenChange={setFavDialogOpen}>
+                                    <DialogTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="icon"
+                                            className="border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:text-white"
+                                            title="Save as favorite"
+                                        >
+                                            ★
+                                        </Button>
+                                    </DialogTrigger>
+                                    <DialogContent>
+                                        <DialogHeader>
+                                            <DialogTitle>Save as Favorite</DialogTitle>
+                                        </DialogHeader>
+                                        <div className="grid gap-3 py-2">
+                                            <Label htmlFor="fav-label">Label</Label>
+                                            <Input
+                                                id="fav-label"
+                                                value={favLabel}
+                                                onChange={(e) => setFavLabel(e.target.value)}
+                                                placeholder="e.g. Actuate valve"
+                                                onKeyDown={(e) => e.key === 'Enter' && saveFavorite()}
+                                            />
+                                        </div>
+                                        <DialogFooter>
+                                            <Button onClick={saveFavorite}>Save</Button>
+                                        </DialogFooter>
+                                    </DialogContent>
+                                </Dialog>
+                            </div>
+
+                            {sendStatus && (
+                                <p className={`text-xs ${sendStatus.type === 'success' ? 'text-green-400' : 'text-red-400'}`}>
+                                    {sendStatus.type === 'success' ? '✓' : '✗'} {sendStatus.message}
+                                </p>
+                            )}
+
+                            {connectionStatus !== 'connected' && (
+                                <p className="text-xs text-zinc-500">Link to Omnibus above to send commands</p>
+                            )}
+                        </div>
+
+                        <Favorites onLoad={loadCommand} />
+                    </div>
+
+                    <CommandHistory onLoad={loadCommand} />
+                </>
             )}
-          />
-
-          {/* msg_prio */}
-          <FormField
-            control={form.control}
-            name="msg_prio"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormLabel className="text-xs text-zinc-400">msg_prio </FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    className="bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500"
-                    placeholder="str"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {/* board_type_id */}
-          <FormField
-            control={form.control}
-            name="board_type_id"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormLabel className="text-xs text-zinc-400">board_type_id </FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    className="bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500"
-                    placeholder="str"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {/* board_inst_id */}
-          <FormField
-            control={form.control}
-            name="board_inst_id"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormLabel className="text-xs text-zinc-400">board_inst_id </FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    className="bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500"
-                    placeholder="str"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-
-          <FormField
-            control={form.control}
-            name="time"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormLabel className="text-xs text-zinc-400">time (s)</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    className="bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-500"
-                    placeholder="int"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          
-         
-
-
-          {/* SEND Button */}
-          <Button
-            type="submit"
-            className="bg-zinc-700 hover:bg-zinc-600 text-white h-9 px-6"
-          >
-            SEND
-          </Button>
         </div>
-      </form>
-    </Form>
-    </div>
-  )
+    )
 }

--- a/packages/renderer/src/components/CanSender/CommandHistory.tsx
+++ b/packages/renderer/src/components/CanSender/CommandHistory.tsx
@@ -1,0 +1,60 @@
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+    onLoad: (cmd: CANCommandMessage) => void
+}
+
+export function CommandHistory({ onLoad }: Props) {
+    const { history, clearHistory } = useCanSenderStore()
+
+    if (history.length === 0) return null
+
+    return (
+        <div className="bg-zinc-900 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-3">
+                <h2 className="text-white font-semibold text-sm">Command History</h2>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-zinc-400 hover:text-zinc-200 text-xs h-7"
+                    onClick={clearHistory}
+                >
+                    Clear
+                </Button>
+            </div>
+            <div className="space-y-1 max-h-48 overflow-y-auto">
+                {history.map((entry) => (
+                    <div
+                        key={entry.id}
+                        className="flex items-center gap-2 text-xs py-1 px-2 rounded hover:bg-zinc-800"
+                    >
+                        <span className={entry.status === 'success' ? 'text-green-400' : 'text-red-400'}>
+                            {entry.status === 'success' ? '✓' : '✗'}
+                        </span>
+                        <span className="text-zinc-500 w-20 shrink-0 tabular-nums">
+                            {new Date(entry.timestamp).toLocaleTimeString()}
+                        </span>
+                        <span className="text-zinc-300 flex-1 truncate">
+                            {entry.command.boardTypeId}/{entry.command.boardInstId}
+                            {' · '}{entry.command.msgType}
+                            {' · '}{entry.command.msgPrio}
+                        </span>
+                        {entry.errorMessage && (
+                            <span className="text-red-400 truncate max-w-[120px]">{entry.errorMessage}</span>
+                        )}
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-2 text-zinc-400 hover:text-white text-xs shrink-0"
+                            onClick={() => onLoad(entry.command)}
+                        >
+                            ↑ Load
+                        </Button>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/packages/renderer/src/components/CanSender/Favorites.tsx
+++ b/packages/renderer/src/components/CanSender/Favorites.tsx
@@ -1,0 +1,43 @@
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+    onLoad: (cmd: CANCommandMessage) => void
+}
+
+export function Favorites({ onLoad }: Props) {
+    const { favorites, removeFavorite } = useCanSenderStore()
+
+    if (favorites.length === 0) return null
+
+    return (
+        <div className="bg-zinc-900 rounded-lg p-4 min-w-[180px]">
+            <h2 className="text-white font-semibold text-sm mb-3">Favorites</h2>
+            <div className="space-y-1">
+                {favorites.map((fav) => (
+                    <div key={fav.id} className="flex items-center gap-1">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="flex-1 justify-start text-zinc-300 hover:text-white text-xs h-7 px-2 truncate"
+                            onClick={() => onLoad(fav.command)}
+                            title={fav.label}
+                        >
+                            {fav.label}
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 shrink-0 text-zinc-500 hover:text-red-400 text-sm"
+                            onClick={() => removeFavorite(fav.id)}
+                            title="Remove favorite"
+                        >
+                            ×
+                        </Button>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/packages/renderer/src/components/OmnibusProvider.tsx
+++ b/packages/renderer/src/components/OmnibusProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { communicator } from '@waterloorocketry/omnibus-ts'
-import type { ParsleyMessage } from '@waterloorocketry/omnibus-ts'
+import type { CANCommandMessage, ParsleyHeartbeatMessage, ParsleyMessage } from '@waterloorocketry/omnibus-ts'
 import { useOmnibusStore } from '@/store/omnibusStore'
 
 type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'error'
@@ -10,8 +10,10 @@ type OmnibusCommunicator = ReturnType<typeof communicator>
 interface OmnibusContextValue {
     connectionStatus: ConnectionStatus
     errorMessage: string
+    parsleyInstances: string[]
     connect: (url: string) => void
     disconnect: () => void
+    sendCommand: (cmd: CANCommandMessage) => void
 }
 
 const OmnibusContext = createContext<OmnibusContextValue | null>(null)
@@ -19,6 +21,7 @@ const OmnibusContext = createContext<OmnibusContextValue | null>(null)
 export function OmnibusProvider({ children }: { children: ReactNode }) {
     const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected')
     const [errorMessage, setErrorMessage] = useState<string>('')
+    const [parsleyInstances, setParsleyInstances] = useState<string[]>([])
     const omnibusRef = useRef<OmnibusCommunicator | null>(null)
     const [serverURL, setServerURL] = useState<string | null>(null)
     const [reconnectCounter, setReconnectCounter] = useState<number>(0)
@@ -58,9 +61,20 @@ export function OmnibusProvider({ children }: { children: ReactNode }) {
             useOmnibusStore.getState().updateSeries(key, msg.payload)
         })
 
+        newOmnibus.receiver.receive<ParsleyHeartbeatMessage>("Parsley/Health", (msg) => {
+            const { id, health } = msg.payload
+            setParsleyInstances((prev) => {
+                if (health === 'Healthy') {
+                    return prev.includes(id) ? prev : [...prev, id]
+                }
+                return prev.filter((i) => i !== id)
+            })
+        })
+
         return () => {
             newOmnibus.disconnect()
             omnibusRef.current = null
+            setParsleyInstances([])
         }
     }, [serverURL, reconnectCounter])
 
@@ -74,10 +88,20 @@ export function OmnibusProvider({ children }: { children: ReactNode }) {
         omnibusRef.current = null
         setServerURL(null)
         setConnectionStatus('disconnected')
+        setParsleyInstances([])
+    }, [])
+
+    const sendCommand = useCallback((cmd: CANCommandMessage) => {
+        if (!omnibusRef.current) throw new Error('Not connected to Omnibus')
+        omnibusRef.current.sender.send<CANCommandMessage>({
+            channel: 'CAN/Commands',
+            timestamp: Date.now(),
+            payload: cmd,
+        })
     }, [])
 
     return (
-        <OmnibusContext.Provider value={{ connectionStatus, errorMessage, connect, disconnect }}>
+        <OmnibusContext.Provider value={{ connectionStatus, errorMessage, parsleyInstances, connect, disconnect, sendCommand }}>
             {children}
         </OmnibusContext.Provider>
     )

--- a/packages/renderer/src/store/canSenderStore.ts
+++ b/packages/renderer/src/store/canSenderStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+
+export interface HistoryEntry {
+    id: string
+    timestamp: number
+    command: CANCommandMessage
+    status: 'success' | 'error'
+    errorMessage?: string
+}
+
+export interface FavoriteEntry {
+    id: string
+    label: string
+    command: CANCommandMessage
+}
+
+interface CanSenderStore {
+    history: HistoryEntry[]
+    favorites: FavoriteEntry[]
+    addToHistory: (entry: Omit<HistoryEntry, 'id'>) => void
+    addFavorite: (label: string, command: CANCommandMessage) => void
+    removeFavorite: (id: string) => void
+    clearHistory: () => void
+}
+
+export const useCanSenderStore = create<CanSenderStore>()(
+    persist(
+        (set) => ({
+            history: [],
+            favorites: [],
+            addToHistory: (entry) =>
+                set((state) => ({
+                    history: [
+                        { ...entry, id: crypto.randomUUID() },
+                        ...state.history.slice(0, 49),
+                    ],
+                })),
+            addFavorite: (label, command) =>
+                set((state) => ({
+                    favorites: [
+                        ...state.favorites,
+                        { id: crypto.randomUUID(), label, command },
+                    ],
+                })),
+            removeFavorite: (id) =>
+                set((state) => ({
+                    favorites: state.favorites.filter((f) => f.id !== id),
+                })),
+            clearHistory: () => set({ history: [] }),
+        }),
+        { name: 'can-sender-store' }
+    )
+)

--- a/packages/renderer/tests/App.test.tsx
+++ b/packages/renderer/tests/App.test.tsx
@@ -49,7 +49,6 @@ describe('App Component', () => {
         expect(screen.getByText('msg_prio')).toBeDefined()
         expect(screen.getByText('board_type_id')).toBeDefined()
         expect(screen.getByText('board_inst_id')).toBeDefined()
-        expect(screen.getByText('time (s)')).toBeDefined()
         expect(screen.getByText('SEND')).toBeDefined()
     })
 })

--- a/packages/renderer/tests/CanSender.test.tsx
+++ b/packages/renderer/tests/CanSender.test.tsx
@@ -1,132 +1,310 @@
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { CanSender } from '@/components/CanSender/CanSender'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import { useOmnibus } from '@/components/OmnibusProvider'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
 
-describe('CanSender Component', () => {
-    it('renders all form fields', () => {
+// ---------------------------------------------------------------------------
+// Mock useOmnibus so we don't need a real socket connection
+// ---------------------------------------------------------------------------
+const mockSendCommand = vi.fn()
+
+vi.mock('@/components/OmnibusProvider', () => ({
+    useOmnibus: vi.fn(() => ({
+        connectionStatus: 'connected',
+        errorMessage: '',
+        parsleyInstances: [],
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        sendCommand: mockSendCommand,
+    })),
+}))
+
+// Mock canSenderStore to isolate component from persistence side-effects
+vi.mock('@/store/canSenderStore', () => {
+    const addToHistory = vi.fn()
+    const addFavorite = vi.fn()
+    const removeFavorite = vi.fn()
+    const clearHistory = vi.fn()
+    return {
+        useCanSenderStore: Object.assign(
+            vi.fn(() => ({ history: [], favorites: [], addToHistory, addFavorite, removeFavorite, clearHistory })),
+            {
+                getState: vi.fn(() => ({ addToHistory, addFavorite, removeFavorite, clearHistory })),
+            }
+        ),
+    }
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fillRequiredFields() {
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i), {
+        target: { value: 'SENSOR_BOARD' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. 0/i), {
+        target: { value: '0' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. ACTUATE/i), {
+        target: { value: 'ACTUATE' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/hostname\/usb\/COM3/i), {
+        target: { value: 'myhostname/usb/COM3' },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CanSender – rendering', () => {
+    it('renders all form fields and SEND button', () => {
         render(<CanSender />)
-
-        expect(screen.getByLabelText(/msg_type/i)).toBeDefined()
-        expect(screen.getByLabelText(/msg_prio/i)).toBeDefined()
-        expect(screen.getByLabelText(/board_type_id/i)).toBeDefined()
-        expect(screen.getByLabelText(/board_inst_id/i)).toBeDefined()
-        expect(screen.getByLabelText(/time/i)).toBeDefined()
-        expect(screen.getByRole('button', { name: /send/i })).toBeDefined()
+        expect(screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i)).toBeDefined()
+        expect(screen.getByPlaceholderText(/e\.g\. 0/i)).toBeDefined()
+        expect(screen.getByPlaceholderText(/e\.g\. ACTUATE/i)).toBeDefined()
+        expect(screen.getByRole('combobox')).toBeDefined() // msg_prio select (no parsley instances → text input)
+        expect(screen.getByPlaceholderText(/DEADBEEF/i)).toBeDefined()
+        expect(screen.getByPlaceholderText(/hostname\/usb\/COM3/i)).toBeDefined()
+        expect(screen.getByRole('button', { name: /^SEND$/ })).toBeDefined()
     })
 
-    it('displays correct placeholders', () => {
+    it('msg_prio select has all four priority options', () => {
         render(<CanSender />)
-
-        const strInputs = screen.getAllByPlaceholderText('str')
-        expect(strInputs.length).toBe(4)
-        expect(screen.getByPlaceholderText('int')).toBeDefined()
+        const select = screen.getByRole('combobox') as HTMLSelectElement
+        const options = Array.from(select.options).map((o) => o.value)
+        expect(options).toEqual(['LOW', 'MEDIUM', 'HIGH', 'HIGHEST'])
     })
 
-    it('accepts valid JSON input', () => {
-        render(<CanSender />)
-
-        const msgTypeInput = screen.getByLabelText(/msg_type/i) as HTMLInputElement
-        fireEvent.change(msgTypeInput, { target: { value: '{"type": 1}' } })
-
-        expect(msgTypeInput.value).toBe('{"type": 1}')
-    })
-
-    it('shows validation error for non-integer time', async () => {
-        render(<CanSender />)
-
-        const timeInput = screen.getByLabelText(/time/i)
-        const submitButton = screen.getByRole('button', { name: /send/i })
-
-        fireEvent.change(timeInput, { target: { value: 'notanumber' } })
-        fireEvent.click(submitButton)
-
-        await waitFor(() => {
-            expect(screen.getByText(/Must be a valid integer/i)).toBeDefined()
+    it('SEND button is disabled when not connected', () => {
+        vi.mocked(useOmnibus).mockReturnValueOnce({
+            connectionStatus: 'disconnected',
+            errorMessage: '',
+            parsleyInstances: [],
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            sendCommand: mockSendCommand,
         })
+        render(<CanSender />)
+        const btn = screen.getByRole('button', { name: /^SEND$/ }) as HTMLButtonElement
+        expect(btn.disabled).toBe(true)
     })
 
-    it('allows empty fields', async () => {
-        const consoleSpy = vi.spyOn(console, 'log')
-        render(<CanSender />)
-
-        const submitButton = screen.getByRole('button', { name: /send/i })
-        fireEvent.click(submitButton)
-
-        // Should submit without errors when all fields are empty
-        await waitFor(() => {
-            expect(consoleSpy).toHaveBeenCalledWith({
-                msg_type: null,
-                msg_prio: null,
-                board_type_id: null,
-                board_inst_id: null,
-                time: null,
-            })
+    it('shows "Connect to Omnibus" hint when disconnected', () => {
+        vi.mocked(useOmnibus).mockReturnValueOnce({
+            connectionStatus: 'disconnected',
+            errorMessage: '',
+            parsleyInstances: [],
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            sendCommand: mockSendCommand,
         })
+        render(<CanSender />)
+        expect(screen.getByText(/link to omnibus/i)).toBeDefined()
+    })
+})
 
-        consoleSpy.mockRestore()
+describe('CanSender – collapsible', () => {
+    it('hides form fields after clicking the toggle', () => {
+        render(<CanSender />)
+        fireEvent.click(screen.getByRole('button', { name: /CAN Sender/i }))
+        expect(screen.queryByPlaceholderText(/e\.g\. SENSOR_BOARD/i)).toBeNull()
     })
 
-    it('submits string values and parses time as integer', async () => {
-        const consoleSpy = vi.spyOn(console, 'log')
+    it('shows form fields again after toggling twice', () => {
         render(<CanSender />)
+        const toggle = screen.getByRole('button', { name: /CAN Sender/i })
+        fireEvent.click(toggle)
+        fireEvent.click(toggle)
+        expect(screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i)).toBeDefined()
+    })
+})
 
-        fireEvent.change(screen.getByLabelText(/msg_type/i), { target: { value: 'SENSOR_ANALOG' } })
-        fireEvent.change(screen.getByLabelText(/msg_prio/i), { target: { value: 'HIGH' } })
-        fireEvent.change(screen.getByLabelText(/board_type_id/i), { target: { value: 'INJ_SENSOR' } })
-        fireEvent.change(screen.getByLabelText(/board_inst_id/i), { target: { value: 'ROCKET' } })
-        fireEvent.change(screen.getByLabelText(/time \(s\)/i), { target: { value: '1234' } })
-
-        fireEvent.click(screen.getByRole('button', { name: /send/i }))
-
-        await waitFor(() => {
-            expect(consoleSpy).toHaveBeenCalledWith({
-                msg_type: 'SENSOR_ANALOG',
-                msg_prio: 'HIGH',
-                board_type_id: 'INJ_SENSOR',
-                board_inst_id: 'ROCKET',
-                time: 1234,
-            })
-        })
-
-        consoleSpy.mockRestore()
+describe('CanSender – validation', () => {
+    beforeEach(() => {
+        mockSendCommand.mockReset()
     })
 
-    it('accepts any string in non-time fields', async () => {
-        const consoleSpy = vi.spyOn(console, 'log')
+    it('shows required errors when sending with empty fields', () => {
         render(<CanSender />)
-
-        fireEvent.change(screen.getByLabelText(/msg_type/i), { target: { value: '{not valid json}' } })
-        fireEvent.change(screen.getByLabelText(/msg_prio/i), { target: { value: 'anything goes' } })
-
-        fireEvent.click(screen.getByRole('button', { name: /send/i }))
-
-        await waitFor(() => {
-            expect(consoleSpy).toHaveBeenCalledWith(expect.objectContaining({
-                msg_type: '{not valid json}',
-                msg_prio: 'anything goes',
-            }))
-        })
-
-        consoleSpy.mockRestore()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        const errors = screen.getAllByText('Required')
+        expect(errors.length).toBe(4) // board_type_id, board_inst_id, msg_type, parsley_instance
     })
 
-    it('clears time validation error when valid integer is entered', async () => {
+    it('shows payload error for invalid hex string', () => {
         render(<CanSender />)
-
-        const timeInput = screen.getByLabelText(/time/i)
-        const submitButton = screen.getByRole('button', { name: /send/i })
-
-        fireEvent.change(timeInput, { target: { value: 'notanumber' } })
-        fireEvent.click(submitButton)
-
-        await waitFor(() => {
-            expect(screen.getByText(/Must be a valid integer/i)).toBeDefined()
+        fillRequiredFields()
+        fireEvent.change(screen.getByPlaceholderText(/DEADBEEF/i), {
+            target: { value: 'ZZZZ' },
         })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getByText(/valid JSON or an even-length hex string/i)).toBeDefined()
+    })
 
-        fireEvent.change(timeInput, { target: { value: '42' } })
-
-        await waitFor(() => {
-            expect(screen.queryByText(/Must be a valid integer/i)).toBeNull()
+    it('shows payload error for odd-length hex string', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.change(screen.getByPlaceholderText(/DEADBEEF/i), {
+            target: { value: 'DEA' },
         })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getByText(/valid JSON or an even-length hex string/i)).toBeDefined()
+    })
+
+    it('shows payload error when hex exceeds 8 bytes', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.change(screen.getByPlaceholderText(/DEADBEEF/i), {
+            target: { value: 'DEADBEEFDEADBEEFFF' }, // 9 bytes
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getByText(/exceeds 8 bytes/i)).toBeDefined()
+    })
+
+    it('does not call sendCommand when validation fails', () => {
+        render(<CanSender />)
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(mockSendCommand).not.toHaveBeenCalled()
+    })
+
+    it('clears field error when user corrects the input', () => {
+        render(<CanSender />)
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getAllByText('Required').length).toBeGreaterThan(0)
+        fireEvent.change(screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i), {
+            target: { value: 'BOARD' },
+        })
+        // Errors for other fields still shown but board_type_id error gone
+        const remaining = screen.getAllByText('Required')
+        expect(remaining.length).toBe(3)
+    })
+})
+
+describe('CanSender – sending', () => {
+    beforeEach(() => {
+        mockSendCommand.mockReset()
+    })
+
+    it('calls sendCommand with correct structure on valid submit', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+
+        expect(mockSendCommand).toHaveBeenCalledOnce()
+        const cmd: CANCommandMessage = mockSendCommand.mock.calls[0][0]
+        expect(cmd.boardTypeId).toBe('SENSOR_BOARD')
+        expect(cmd.boardInstId).toBe('0')
+        expect(cmd.msgType).toBe('ACTUATE')
+        expect(cmd.msgPrio).toBe('MEDIUM') // default
+        expect(cmd.canMsg).toBeNull()
+        expect(cmd.parsley).toBe('myhostname/usb/COM3')
+        expect(cmd.messageFormatVersion).toBe(2)
+    })
+
+    it('sends correct priority when changed', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'HIGH' } })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        const cmd: CANCommandMessage = mockSendCommand.mock.calls[0][0]
+        expect(cmd.msgPrio).toBe('HIGH')
+    })
+
+    it('parses hex payload into byte array', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.change(screen.getByPlaceholderText(/DEADBEEF/i), {
+            target: { value: '8FFF' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        const cmd: CANCommandMessage = mockSendCommand.mock.calls[0][0]
+        expect(cmd.canMsg).toEqual([0x8f, 0xff])
+    })
+
+    it('parses JSON payload into object', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.change(screen.getByPlaceholderText(/DEADBEEF/i), {
+            target: { value: '{"key": 42}' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        const cmd: CANCommandMessage = mockSendCommand.mock.calls[0][0]
+        expect(cmd.canMsg).toEqual({ key: 42 })
+    })
+
+    it('shows success status after send', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getByText(/command sent/i)).toBeDefined()
+    })
+
+    it('shows error status when sendCommand throws', () => {
+        mockSendCommand.mockImplementationOnce(() => {
+            throw new Error('Not connected to Omnibus')
+        })
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(screen.getByText(/not connected to omnibus/i)).toBeDefined()
+    })
+
+    it('does not clear field values after a successful send', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        const input = screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i) as HTMLInputElement
+        expect(input.value).toBe('SENSOR_BOARD')
+    })
+
+    it('adds entry to history after successful send', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(useCanSenderStore.getState().addToHistory).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'success' })
+        )
+    })
+
+    it('adds error entry to history when sendCommand throws', () => {
+        mockSendCommand.mockImplementationOnce(() => { throw new Error('oops') })
+        render(<CanSender />)
+        fillRequiredFields()
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(useCanSenderStore.getState().addToHistory).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'error', errorMessage: 'oops' })
+        )
+    })
+})
+
+describe('CanSender – load command', () => {
+    it('populates fields when loadCommand is called via history', () => {
+        const cmd: CANCommandMessage = {
+            boardTypeId: 'FLIGHT_COMPUTER',
+            boardInstId: '1',
+            msgType: 'ARM',
+            msgPrio: 'HIGHEST',
+            canMsg: null,
+            parsley: '',
+            messageFormatVersion: 2,
+        }
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: cmd, status: 'success' }],
+            favorites: [],
+            addToHistory: vi.fn(),
+            addFavorite: vi.fn(),
+            removeFavorite: vi.fn(),
+            clearHistory: vi.fn(),
+        })
+        render(<CanSender />)
+        fireEvent.click(screen.getByText('↑ Load'))
+        expect((screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i) as HTMLInputElement).value).toBe('FLIGHT_COMPUTER')
+        expect((screen.getByPlaceholderText(/e\.g\. 0/i) as HTMLInputElement).value).toBe('1')
+        expect((screen.getByPlaceholderText(/e\.g\. ACTUATE/i) as HTMLInputElement).value).toBe('ARM')
+        expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('HIGHEST')
     })
 })

--- a/packages/renderer/tests/CanSender.test.tsx
+++ b/packages/renderer/tests/CanSender.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { CanSender } from '@/components/CanSender/CanSender'
 import { useCanSenderStore } from '@/store/canSenderStore'
@@ -278,6 +278,110 @@ describe('CanSender – sending', () => {
         expect(useCanSenderStore.getState().addToHistory).toHaveBeenCalledWith(
             expect.objectContaining({ status: 'error', errorMessage: 'oops' })
         )
+    })
+})
+
+describe('CanSender – save favorite', () => {
+    beforeEach(() => {
+        mockSendCommand.mockReset()
+        // Reset the getState addFavorite mock so call counts are clean
+        vi.mocked(useCanSenderStore.getState().addFavorite).mockReset()
+    })
+
+    it('saves a favorite with custom label via the dialog', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+
+        fireEvent.click(screen.getByTitle('Save as favorite'))
+        fireEvent.change(screen.getByPlaceholderText(/Actuate valve/i), {
+            target: { value: 'My Command' },
+        })
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+
+        const addFavorite = useCanSenderStore.getState().addFavorite
+        expect(addFavorite).toHaveBeenCalledOnce()
+        expect((addFavorite as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('My Command')
+        expect((addFavorite as ReturnType<typeof vi.fn>).mock.calls[0][1].boardTypeId).toBe('SENSOR_BOARD')
+    })
+
+    it('uses board_type_id/msg_type as default label when label is empty', () => {
+        render(<CanSender />)
+        fillRequiredFields()
+
+        fireEvent.click(screen.getByTitle('Save as favorite'))
+        // leave label empty, click Save
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+
+        const addFavorite = useCanSenderStore.getState().addFavorite
+        expect(addFavorite).toHaveBeenCalledOnce()
+        expect((addFavorite as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('SENSOR_BOARD/ACTUATE')
+    })
+
+    it('does not save when required fields are invalid', () => {
+        render(<CanSender />)
+        // Don't fill required fields — open dialog and try to save
+        fireEvent.click(screen.getByTitle('Save as favorite'))
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+
+        expect(useCanSenderStore.getState().addFavorite).not.toHaveBeenCalled()
+    })
+})
+
+describe('CanSender – parsley instance dropdown', () => {
+    // These tests need parsleyInstances to persist across re-renders triggered
+    // by field changes, so we set a persistent mock for the whole describe block
+    // and restore the default afterwards.
+    beforeEach(() => {
+        mockSendCommand.mockReset()
+        vi.mocked(useOmnibus).mockReturnValue({
+            connectionStatus: 'connected',
+            errorMessage: '',
+            parsleyInstances: ['host1/usb/COM3', 'host1/usb/COM4'],
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            sendCommand: mockSendCommand,
+        })
+    })
+
+    afterEach(() => {
+        vi.mocked(useOmnibus).mockReturnValue({
+            connectionStatus: 'connected',
+            errorMessage: '',
+            parsleyInstances: [],
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            sendCommand: mockSendCommand,
+        })
+    })
+
+    it('renders a select dropdown when parsleyInstances are available', () => {
+        render(<CanSender />)
+        const selects = screen.getAllByRole('combobox')
+        // Two comboboxes: msg_prio and parsley instance
+        expect(selects.length).toBe(2)
+        const parsleySelect = selects[1] as HTMLSelectElement
+        const options = Array.from(parsleySelect.options).map((o) => o.value)
+        expect(options).toContain('host1/usb/COM3')
+        expect(options).toContain('host1/usb/COM4')
+    })
+
+    it('selecting a parsley instance sets the field value', () => {
+        render(<CanSender />)
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[1], { target: { value: 'host1/usb/COM3' } })
+        expect((selects[1] as HTMLSelectElement).value).toBe('host1/usb/COM3')
+    })
+
+    it('sends command with selected parsley instance', () => {
+        render(<CanSender />)
+        fireEvent.change(screen.getByPlaceholderText(/e\.g\. SENSOR_BOARD/i), { target: { value: 'SENSOR_BOARD' } })
+        fireEvent.change(screen.getByPlaceholderText(/e\.g\. 0/i), { target: { value: '0' } })
+        fireEvent.change(screen.getByPlaceholderText(/e\.g\. ACTUATE/i), { target: { value: 'ACTUATE' } })
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[1], { target: { value: 'host1/usb/COM3' } })
+        fireEvent.click(screen.getByRole('button', { name: /^SEND$/ }))
+        expect(mockSendCommand).toHaveBeenCalledOnce()
+        expect(mockSendCommand.mock.calls[0][0].parsley).toBe('host1/usb/COM3')
     })
 })
 

--- a/packages/renderer/tests/CommandHistory.test.tsx
+++ b/packages/renderer/tests/CommandHistory.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CommandHistory } from '@/components/CanSender/CommandHistory'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+
+vi.mock('@/store/canSenderStore', () => {
+    const clearHistory = vi.fn()
+    return {
+        useCanSenderStore: Object.assign(
+            vi.fn(() => ({ history: [], clearHistory })),
+            { getState: vi.fn(() => ({ clearHistory })) }
+        ),
+    }
+})
+
+const mockCmd = (overrides: Partial<CANCommandMessage> = {}): CANCommandMessage => ({
+    boardTypeId: 'SENSOR_BOARD',
+    boardInstId: '0',
+    msgType: 'ACTUATE',
+    msgPrio: 'MEDIUM',
+    canMsg: null,
+    parsley: '',
+    messageFormatVersion: 2,
+    ...overrides,
+})
+
+describe('CommandHistory', () => {
+    beforeEach(() => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [],
+            clearHistory: vi.fn(),
+        } as any)
+    })
+
+    it('renders nothing when history is empty', () => {
+        const { container } = render(<CommandHistory onLoad={vi.fn()} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders an entry for each history item', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [
+                { id: '1', timestamp: Date.now(), command: mockCmd(), status: 'success' },
+                { id: '2', timestamp: Date.now(), command: mockCmd({ boardTypeId: 'FLIGHT_COMPUTER' }), status: 'error', errorMessage: 'oops' },
+            ],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        const loadButtons = screen.getAllByText('↑ Load')
+        expect(loadButtons.length).toBe(2)
+    })
+
+    it('shows board/msg summary text', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [
+                { id: '1', timestamp: Date.now(), command: mockCmd(), status: 'success' },
+            ],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        expect(screen.getByText(/SENSOR_BOARD\/0/)).toBeDefined()
+        expect(screen.getByText(/ACTUATE/)).toBeDefined()
+        expect(screen.getByText(/MEDIUM/)).toBeDefined()
+    })
+
+    it('shows ✓ badge for successful entries', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: mockCmd(), status: 'success' }],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        expect(screen.getByText('✓')).toBeDefined()
+    })
+
+    it('shows ✗ badge for error entries', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: mockCmd(), status: 'error', errorMessage: 'failed' }],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        expect(screen.getByText('✗')).toBeDefined()
+    })
+
+    it('shows error message text when present', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: mockCmd(), status: 'error', errorMessage: 'Not connected' }],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        expect(screen.getByText('Not connected')).toBeDefined()
+    })
+
+    it('does not show error message text for successful entries', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: mockCmd(), status: 'success' }],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        expect(screen.queryByText('Not connected')).toBeNull()
+    })
+
+    it('calls onLoad with the command when Load button is clicked', () => {
+        const cmd = mockCmd({ boardTypeId: 'FLIGHT_COMPUTER' })
+        const onLoad = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: cmd, status: 'success' }],
+            clearHistory: vi.fn(),
+        } as any)
+        render(<CommandHistory onLoad={onLoad} />)
+        fireEvent.click(screen.getByText('↑ Load'))
+        expect(onLoad).toHaveBeenCalledOnce()
+        expect(onLoad).toHaveBeenCalledWith(cmd)
+    })
+
+    it('calls clearHistory when Clear button is clicked', () => {
+        const clearHistory = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            history: [{ id: '1', timestamp: Date.now(), command: mockCmd(), status: 'success' }],
+            clearHistory,
+        } as any)
+        render(<CommandHistory onLoad={vi.fn()} />)
+        fireEvent.click(screen.getByText('Clear'))
+        expect(clearHistory).toHaveBeenCalledOnce()
+    })
+})

--- a/packages/renderer/tests/Favorites.test.tsx
+++ b/packages/renderer/tests/Favorites.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Favorites } from '@/components/CanSender/Favorites'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+
+vi.mock('@/store/canSenderStore', () => {
+    const removeFavorite = vi.fn()
+    return {
+        useCanSenderStore: Object.assign(
+            vi.fn(() => ({ favorites: [], removeFavorite })),
+            { getState: vi.fn(() => ({ removeFavorite })) }
+        ),
+    }
+})
+
+const mockCmd = (overrides: Partial<CANCommandMessage> = {}): CANCommandMessage => ({
+    boardTypeId: 'SENSOR_BOARD',
+    boardInstId: '0',
+    msgType: 'ACTUATE',
+    msgPrio: 'MEDIUM',
+    canMsg: null,
+    parsley: '',
+    messageFormatVersion: 2,
+    ...overrides,
+})
+
+describe('Favorites', () => {
+    beforeEach(() => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [],
+            removeFavorite: vi.fn(),
+        } as any)
+    })
+
+    it('renders nothing when favorites is empty', () => {
+        const { container } = render(<Favorites onLoad={vi.fn()} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders a button for each favorite label', () => {
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [
+                { id: '1', label: 'Actuate valve', command: mockCmd() },
+                { id: '2', label: 'Arm flight computer', command: mockCmd({ boardTypeId: 'FLIGHT_COMPUTER' }) },
+            ],
+            removeFavorite: vi.fn(),
+        } as any)
+        render(<Favorites onLoad={vi.fn()} />)
+        expect(screen.getByText('Actuate valve')).toBeDefined()
+        expect(screen.getByText('Arm flight computer')).toBeDefined()
+    })
+
+    it('calls onLoad with the command when a favorite label is clicked', () => {
+        const cmd = mockCmd({ msgType: 'ARM' })
+        const onLoad = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [{ id: '1', label: 'Arm', command: cmd }],
+            removeFavorite: vi.fn(),
+        } as any)
+        render(<Favorites onLoad={onLoad} />)
+        fireEvent.click(screen.getByText('Arm'))
+        expect(onLoad).toHaveBeenCalledOnce()
+        expect(onLoad).toHaveBeenCalledWith(cmd)
+    })
+
+    it('calls removeFavorite with the correct id when × is clicked', () => {
+        const removeFavorite = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [{ id: 'abc-123', label: 'My fav', command: mockCmd() }],
+            removeFavorite,
+        } as any)
+        render(<Favorites onLoad={vi.fn()} />)
+        fireEvent.click(screen.getByTitle('Remove favorite'))
+        expect(removeFavorite).toHaveBeenCalledOnce()
+        expect(removeFavorite).toHaveBeenCalledWith('abc-123')
+    })
+
+    it('calls removeFavorite with the correct id for each respective × button', () => {
+        const removeFavorite = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [
+                { id: 'id-1', label: 'First', command: mockCmd() },
+                { id: 'id-2', label: 'Second', command: mockCmd() },
+            ],
+            removeFavorite,
+        } as any)
+        render(<Favorites onLoad={vi.fn()} />)
+        const removeButtons = screen.getAllByTitle('Remove favorite')
+        fireEvent.click(removeButtons[1])
+        expect(removeFavorite).toHaveBeenCalledWith('id-2')
+    })
+
+    it('calls onLoad only for the clicked favorite, not others', () => {
+        const onLoad = vi.fn()
+        vi.mocked(useCanSenderStore).mockReturnValue({
+            favorites: [
+                { id: '1', label: 'First', command: mockCmd({ msgType: 'FIRST' }) },
+                { id: '2', label: 'Second', command: mockCmd({ msgType: 'SECOND' }) },
+            ],
+            removeFavorite: vi.fn(),
+        } as any)
+        render(<Favorites onLoad={onLoad} />)
+        fireEvent.click(screen.getByText('Second'))
+        expect(onLoad).toHaveBeenCalledOnce()
+        expect(onLoad.mock.calls[0][0].msgType).toBe('SECOND')
+    })
+})

--- a/packages/renderer/tests/OmnibusProvider.test.tsx
+++ b/packages/renderer/tests/OmnibusProvider.test.tsx
@@ -1,16 +1,18 @@
+import React from 'react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import { OmnibusProvider, useOmnibus } from '@/components/OmnibusProvider'
 
 // --- Hoist mocks so they're available when vi.mock factory runs ---
-const { mockOn, mockDisconnect, mockReceive, mockCommunicator, mockUpdateSeries } = vi.hoisted(
+const { mockOn, mockEmit, mockDisconnect, mockReceive, mockCommunicator, mockUpdateSeries } = vi.hoisted(
     () => {
         const mockOn = vi.fn()
+        const mockEmit = vi.fn()
         const mockDisconnect = vi.fn()
         const mockUpdateSeries = vi.fn()
         const mockReceive = vi.fn()
         const mockCommunicator = vi.fn(() => ({
-            socket: { on: mockOn },
+            socket: { on: mockOn, emit: mockEmit },
             disconnect: mockDisconnect,
             sender: { send: vi.fn() },
             receiver: {
@@ -18,7 +20,7 @@ const { mockOn, mockDisconnect, mockReceive, mockCommunicator, mockUpdateSeries 
                 receiveAll: vi.fn(),
             },
         }))
-        return { mockOn, mockDisconnect, mockReceive, mockCommunicator, mockUpdateSeries }
+        return { mockOn, mockEmit, mockDisconnect, mockReceive, mockCommunicator, mockUpdateSeries }
     }
 )
 
@@ -52,13 +54,18 @@ function emitReceiveEvent(channel: string, payload: unknown) {
 
 // --- Test component that exposes provider state ---
 function StatusDisplay() {
-    const { connectionStatus, errorMessage, connect, disconnect } = useOmnibus()
+    const { connectionStatus, errorMessage, parsleyInstances, connect, disconnect, sendCommand } = useOmnibus()
+    const [sendError, setSendError] = React.useState('')
+    const cmd = { boardTypeId: 'SENSOR_BOARD', boardInstId: '0', msgType: 'ACTUATE', msgPrio: 'MEDIUM' as const, canMsg: null, parsley: '', messageFormatVersion: 2 as const }
     return (
         <div>
             <span data-testid="status">{connectionStatus}</span>
             <span data-testid="error">{errorMessage}</span>
+            <span data-testid="send-error">{sendError}</span>
+            <span data-testid="parsley-instances">{parsleyInstances.join(',')}</span>
             <button onClick={() => connect('http://localhost:8081')}>connect</button>
             <button onClick={disconnect}>disconnect</button>
+            <button onClick={() => { try { sendCommand(cmd) } catch (e) { setSendError((e as Error).message) } }}>send</button>
         </div>
     )
 }
@@ -74,12 +81,13 @@ function renderWithProvider() {
 describe('OmnibusProvider', () => {
     beforeEach(() => {
         mockOn.mockClear()
+        mockEmit.mockClear()
         mockDisconnect.mockClear()
         mockCommunicator.mockClear()
         mockReceive.mockClear()
         mockUpdateSeries.mockClear()
         mockCommunicator.mockReturnValue({
-            socket: { on: mockOn },
+            socket: { on: mockOn, emit: mockEmit },
             disconnect: mockDisconnect,
             sender: { send: vi.fn() },
             receiver: {
@@ -202,6 +210,82 @@ describe('OmnibusProvider', () => {
                 boardInstId: 'inst1',
                 data: { status: 'OK', value: 42 },
             })
+        })
+    })
+})
+
+describe('OmnibusProvider – sendCommand', () => {
+    beforeEach(() => {
+        mockOn.mockClear()
+        mockEmit.mockClear()
+        mockDisconnect.mockClear()
+        mockCommunicator.mockClear()
+        mockReceive.mockClear()
+        mockUpdateSeries.mockClear()
+        mockCommunicator.mockReturnValue({
+            socket: { on: mockOn, emit: mockEmit },
+            disconnect: mockDisconnect,
+            sender: { send: vi.fn() },
+            receiver: { receive: mockReceive, receiveAll: vi.fn() },
+        })
+    })
+
+    it('calls sender.send on CAN/Commands channel with the CANCommandMessage payload', async () => {
+        const mockSend = vi.fn()
+        mockCommunicator.mockReturnValueOnce({
+            socket: { on: mockOn, emit: mockEmit },
+            disconnect: mockDisconnect,
+            sender: { send: mockSend },
+            receiver: { receive: mockReceive, receiveAll: vi.fn() },
+        })
+        renderWithProvider()
+        act(() => { screen.getByText('connect').click() })
+        act(() => { emitSocketEvent('connect') })
+        await waitFor(() => {
+            expect(screen.getByTestId('status').textContent).toBe('connected')
+        })
+
+        act(() => { screen.getByText('send').click() })
+
+        expect(mockSend).toHaveBeenCalledOnce()
+        const msg = mockSend.mock.calls[0][0]
+        expect(msg.channel).toBe('CAN/Commands')
+        expect(typeof msg.timestamp).toBe('number')
+        expect(msg.payload.boardTypeId).toBe('SENSOR_BOARD')
+        expect(msg.payload.msgType).toBe('ACTUATE')
+        expect(msg.payload.msgPrio).toBe('MEDIUM')
+        expect(msg.payload.messageFormatVersion).toBe(2)
+    })
+
+    it('exposes error message when sendCommand is called before connecting', async () => {
+        renderWithProvider()
+        // Do not connect — omnibusRef is null
+        act(() => { screen.getByText('send').click() })
+        await waitFor(() => {
+            expect(screen.getByTestId('send-error').textContent).toBe('Not connected to Omnibus')
+        })
+    })
+
+    it('subscribes to Parsley/Health and exposes live instances', async () => {
+        renderWithProvider()
+        act(() => { screen.getByText('connect').click() })
+        act(() => { emitSocketEvent('connect') })
+        await waitFor(() => {
+            expect(screen.getByTestId('status').textContent).toBe('connected')
+        })
+
+        act(() => {
+            emitReceiveEvent('Parsley/Health', { id: 'myhost/usb/COM3', health: 'Healthy' })
+        })
+        await waitFor(() => {
+            expect(screen.getByTestId('parsley-instances').textContent).toContain('myhost/usb/COM3')
+        })
+
+        act(() => {
+            emitReceiveEvent('Parsley/Health', { id: 'myhost/usb/COM3', health: 'Dead' })
+        })
+        await waitFor(() => {
+            expect(screen.getByTestId('parsley-instances').textContent).toBe('')
         })
     })
 })

--- a/packages/renderer/tests/canSenderStore.test.ts
+++ b/packages/renderer/tests/canSenderStore.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { useCanSenderStore } from '@/store/canSenderStore'
+import type { CANCommandMessage } from '@waterloorocketry/omnibus-ts'
+
+const BASE_CMD: CANCommandMessage = {
+    boardTypeId: 'SENSOR_BOARD',
+    boardInstId: '0',
+    msgType: 'ACTUATE',
+    msgPrio: 'MEDIUM',
+    canMsg: null,
+    parsley: '',
+    messageFormatVersion: 2,
+}
+
+function resetStore() {
+    useCanSenderStore.setState({ history: [], favorites: [] })
+}
+
+describe('canSenderStore – history', () => {
+    beforeEach(resetStore)
+
+    it('starts with empty history', () => {
+        expect(useCanSenderStore.getState().history).toHaveLength(0)
+    })
+
+    it('addToHistory prepends an entry with a generated id', () => {
+        useCanSenderStore.getState().addToHistory({
+            timestamp: 1000,
+            command: BASE_CMD,
+            status: 'success',
+        })
+        const { history } = useCanSenderStore.getState()
+        expect(history).toHaveLength(1)
+        expect(history[0].id).toBeTruthy()
+        expect(history[0].status).toBe('success')
+        expect(history[0].command).toEqual(BASE_CMD)
+    })
+
+    it('addToHistory prepends so newest entry is first', () => {
+        useCanSenderStore.getState().addToHistory({ timestamp: 1000, command: BASE_CMD, status: 'success' })
+        useCanSenderStore.getState().addToHistory({ timestamp: 2000, command: { ...BASE_CMD, msgType: 'SECOND' }, status: 'success' })
+        const { history } = useCanSenderStore.getState()
+        expect(history[0].command.msgType).toBe('SECOND')
+        expect(history[1].command.msgType).toBe('ACTUATE')
+    })
+
+    it('stores error message on failed entries', () => {
+        useCanSenderStore.getState().addToHistory({
+            timestamp: 1000,
+            command: BASE_CMD,
+            status: 'error',
+            errorMessage: 'Not connected',
+        })
+        expect(useCanSenderStore.getState().history[0].errorMessage).toBe('Not connected')
+    })
+
+    it('each entry has a unique id', () => {
+        useCanSenderStore.getState().addToHistory({ timestamp: 1, command: BASE_CMD, status: 'success' })
+        useCanSenderStore.getState().addToHistory({ timestamp: 2, command: BASE_CMD, status: 'success' })
+        const { history } = useCanSenderStore.getState()
+        expect(history[0].id).not.toBe(history[1].id)
+    })
+
+    it('caps history at 50 entries', () => {
+        for (let i = 0; i < 55; i++) {
+            useCanSenderStore.getState().addToHistory({ timestamp: i, command: BASE_CMD, status: 'success' })
+        }
+        expect(useCanSenderStore.getState().history).toHaveLength(50)
+    })
+
+    it('discards oldest entries when cap is exceeded', () => {
+        for (let i = 0; i < 50; i++) {
+            useCanSenderStore.getState().addToHistory({
+                timestamp: i,
+                command: { ...BASE_CMD, msgType: `MSG_${i}` },
+                status: 'success',
+            })
+        }
+        // Add one more — oldest (MSG_0) should be gone
+        useCanSenderStore.getState().addToHistory({
+            timestamp: 99,
+            command: { ...BASE_CMD, msgType: 'NEWEST' },
+            status: 'success',
+        })
+        const { history } = useCanSenderStore.getState()
+        expect(history).toHaveLength(50)
+        expect(history[0].command.msgType).toBe('NEWEST')
+        expect(history.find((e) => e.command.msgType === 'MSG_0')).toBeUndefined()
+    })
+
+    it('clearHistory empties the list', () => {
+        useCanSenderStore.getState().addToHistory({ timestamp: 1, command: BASE_CMD, status: 'success' })
+        useCanSenderStore.getState().clearHistory()
+        expect(useCanSenderStore.getState().history).toHaveLength(0)
+    })
+})
+
+describe('canSenderStore – favorites', () => {
+    beforeEach(resetStore)
+
+    it('starts with empty favorites', () => {
+        expect(useCanSenderStore.getState().favorites).toHaveLength(0)
+    })
+
+    it('addFavorite appends an entry with label and generated id', () => {
+        useCanSenderStore.getState().addFavorite('Actuate valve', BASE_CMD)
+        const { favorites } = useCanSenderStore.getState()
+        expect(favorites).toHaveLength(1)
+        expect(favorites[0].label).toBe('Actuate valve')
+        expect(favorites[0].command).toEqual(BASE_CMD)
+        expect(favorites[0].id).toBeTruthy()
+    })
+
+    it('can add multiple favorites', () => {
+        useCanSenderStore.getState().addFavorite('First', BASE_CMD)
+        useCanSenderStore.getState().addFavorite('Second', { ...BASE_CMD, msgType: 'OTHER' })
+        expect(useCanSenderStore.getState().favorites).toHaveLength(2)
+    })
+
+    it('each favorite has a unique id', () => {
+        useCanSenderStore.getState().addFavorite('A', BASE_CMD)
+        useCanSenderStore.getState().addFavorite('B', BASE_CMD)
+        const { favorites } = useCanSenderStore.getState()
+        expect(favorites[0].id).not.toBe(favorites[1].id)
+    })
+
+    it('removeFavorite removes the entry with the given id', () => {
+        useCanSenderStore.getState().addFavorite('Keep', BASE_CMD)
+        useCanSenderStore.getState().addFavorite('Remove', BASE_CMD)
+        const idToRemove = useCanSenderStore.getState().favorites.find((f) => f.label === 'Remove')!.id
+        useCanSenderStore.getState().removeFavorite(idToRemove)
+        const { favorites } = useCanSenderStore.getState()
+        expect(favorites).toHaveLength(1)
+        expect(favorites[0].label).toBe('Keep')
+    })
+
+    it('removeFavorite with unknown id is a no-op', () => {
+        useCanSenderStore.getState().addFavorite('Keep', BASE_CMD)
+        useCanSenderStore.getState().removeFavorite('nonexistent-id')
+        expect(useCanSenderStore.getState().favorites).toHaveLength(1)
+    })
+})


### PR DESCRIPTION
Implements the CAN Sender module for arbitrary CAN commands over Omnibus-TS

Implements command history, favourites, parsley instance selector - also implements a mock-server for local development without the need for a full omnibus stack.

Adds the following:

OmnibusProvider — adds sendCommand(cmd: CANCommandMessage) and parsleyInstances: string[] to context; subscribes to Parsley/Health to discover live parsley instances
CanSender — collapsible form with board_type_id, board_inst_id, msg_type, msg_prio, optional payload (JSON or hex ≤8 bytes), and parsley instance fields; send status feedback; save-as-favorite dialog
CommandHistory — scrollable list of last 50 sent commands with status badges and load-back button
Favorites — labeled saved commands with load and delete actions
canSenderStore — Zustand store with persist middleware for history and favorites
mock-server/ — Socket.IO + msgpack server that emits fake board data on connect and logs received commands

<img width="1886" height="805" alt="image" src="https://github.com/user-attachments/assets/24483e6b-a394-4379-8a06-d37a6b498128" />
<img width="1890" height="425" alt="image" src="https://github.com/user-attachments/assets/9f93f587-57e5-4305-b3ed-b6d4a6459038" />

Test report:
<img width="1354" height="941" alt="image" src="https://github.com/user-attachments/assets/e4dd01b4-3471-4f78-a33a-01b31c6a97a2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CAN command sender with improved form validation supporting JSON and hex payloads
  * Command favorites feature to save and quickly load frequently used commands
  * Command history tracking with ability to reload and review previous commands
  * Connection status indication and send feedback in the command sender interface
  * Collapsible command sender form for better UI organization

* **Tests**
  * Expanded test coverage for command sending and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->